### PR TITLE
Not able to use PageSlider inside Webpack compilation

### DIFF
--- a/src/page-slider.js
+++ b/src/page-slider.js
@@ -9,7 +9,7 @@
      if (typeof define === 'function' && define.amd) {
          // AMD. Register as an anonymous module.
          define(['jquery'], factory);
-     } else if (typeof exports === 'object') {
+     } else if (typeof exports === 'object' && typeof require === 'function') {
          // Node.
          module.exports = factory(require('jquery'));
      } else {


### PR DESCRIPTION
Hi, I was not able to use PageSlider inside a Webpack compilation. So I made this very simple change and it works correctly. It would be great if you could merge it so I can keep up with any future modification you or others make.
Regards
